### PR TITLE
Make sure tooltips are always-on-top

### DIFF
--- a/src/tooltip/index.js
+++ b/src/tooltip/index.js
@@ -12,6 +12,7 @@ class Tooltip extends CanvasLayer {
     this.linesMargin = 4;
     this.width = 0;
     this.height = 0;
+    this.zIndex = 999;
     this.addChild(this.container);
   }
 


### PR DESCRIPTION
There's probably a more proper way of solving this, but setting the
zIndex to 999 seems to be a very pragmatic, if not elegant, way.

![bug](https://media.discordapp.net/attachments/779868865844215818/780378375595360266/unknown.png)