### PR TITLE
Fix movement tooltip for dnd5e

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -147,6 +147,21 @@ class App extends Application {
         };
       };
 
+      const getSpeed = move => {
+        let extra = [];
+        if (move.fly)    extra.push(`${move.fly} ${move.units} fly`);
+        if (move.hover)  extra.push("hover");
+        if (move.burrow) extra.push(`${move.burrow} ${move.units} burrow`);
+        if (move.swim)   extra.push(`${move.swim} ${move.units} swim`);
+        if (move.climb)  extra.push(`${move.climb} ${move.units} climb`);
+
+        let str = `${move.walk} ${move.units}`;
+        if (extra.length)
+          str += ` (${extra.join(", ")})`;
+
+        return str;
+      };
+
       return {
         id: actor.id,
         isHidden: this.hiddenActors.includes(actor.id),
@@ -159,7 +174,7 @@ class App extends Application {
         hp: getHitpoints(data.attributes.hp),
         ac: data.attributes.ac.value ? data.attributes.ac.value : 10,
         spellDC: data.attributes.spelldc,
-        speed: data.attributes.speed.value,
+        speed: getSpeed(data.attributes.movement),
 
         // passive stuff
         passives: {


### PR DESCRIPTION
This was changed from a single value to a dict of different values. The
new getSpeed() function converts this to a friendly-printed string by
listing only relevant movement types.

![tooltip](https://user-images.githubusercontent.com/1149047/100139602-0345b380-2e90-11eb-8428-4f75ba927867.jpg)